### PR TITLE
fix: add missing globalCanvas and globalCtx variable declarations

### DIFF
--- a/three.min.js
+++ b/three.min.js
@@ -2,6 +2,10 @@
 (function() {
     'use strict';
     
+    // Global variables for canvas and context
+    let globalCanvas = null;
+    let globalCtx = null;
+    
     // Basic 3D math utilities
     function Vector3(x = 0, y = 0, z = 0) {
         this.x = x;


### PR DESCRIPTION
Resolves initialization error where WebGLRenderer constructor was attempting to assign values to undeclared global variables.

Fixes #28

Generated with [Claude Code](https://claude.ai/code)