### PR TITLE
Fix texture repeat.set() method error

### DIFF
--- a/three.min.js
+++ b/three.min.js
@@ -508,7 +508,14 @@
     function Texture() {
         this.wrapS = 'clamp-to-edge';
         this.wrapT = 'clamp-to-edge';
-        this.repeat = { x: 1, y: 1 };
+        this.repeat = { 
+            x: 1, 
+            y: 1,
+            set: function(x, y) {
+                this.x = x;
+                this.y = y;
+            }
+        };
         this.needsUpdate = true;
     }
     
@@ -547,7 +554,14 @@
                 needsUpdate: true,
                 wrapS: 'clamp-to-edge',
                 wrapT: 'clamp-to-edge',
-                repeat: { x: 1, y: 1 }
+                repeat: { 
+                    x: 1, 
+                    y: 1,
+                    set: function(x, y) {
+                        this.x = x;
+                        this.y = y;
+                    }
+                }
             };
             console.log('Created fallback texture:', fallbackTexture);
             return fallbackTexture;


### PR DESCRIPTION
Fixes issue #30 - ゲームの始まりに失敗

Added missing `set(x, y)` method to Texture.repeat property to resolve `TypeError: wallTexture.repeat.set is not a function` error.

Generated with [Claude Code](https://claude.ai/code)