### PR TITLE
Fix MeshPhongMaterial constructor error

### DIFF
--- a/three.min.js
+++ b/three.min.js
@@ -146,6 +146,37 @@
         return { r: 1, g: 1, b: 1 };
     };
     
+    // MeshPhongMaterial (same as MeshLambertMaterial for compatibility)
+    function MeshPhongMaterial(params = {}) {
+        Material.call(this);
+        if (params.color !== undefined) {
+            this.color = this.parseColor(params.color);
+        }
+        if (params.transparent !== undefined) {
+            this.transparent = params.transparent;
+        }
+        if (params.wireframe !== undefined) {
+            this.wireframe = params.wireframe;
+        }
+        // Additional Phong properties (for compatibility, not implemented)
+        this.shininess = params.shininess || 30;
+        this.emissive = params.emissive || 0x000000;
+        this.specular = params.specular || 0x111111;
+    }
+    MeshPhongMaterial.prototype = Object.create(Material.prototype);
+    MeshPhongMaterial.prototype.constructor = MeshPhongMaterial;
+    
+    MeshPhongMaterial.prototype.parseColor = function(color) {
+        if (typeof color === 'number') {
+            return {
+                r: ((color >> 16) & 255) / 255,
+                g: ((color >> 8) & 255) / 255,
+                b: (color & 255) / 255
+            };
+        }
+        return { r: 1, g: 1, b: 1 };
+    };
+    
     // Geometry classes
     function Geometry() {
         this.vertices = [];
@@ -586,6 +617,7 @@
         PlaneGeometry: PlaneGeometry,
         CylinderGeometry: CylinderGeometry,
         MeshLambertMaterial: MeshLambertMaterial,
+        MeshPhongMaterial: MeshPhongMaterial,
         Mesh: Mesh,
         AmbientLight: AmbientLight,
         DirectionalLight: DirectionalLight,


### PR DESCRIPTION
Fixes issue #30 - ゲームの始まりに失敗

Added missing MeshPhongMaterial class to resolve `TypeError: THREE.MeshPhongMaterial is not a constructor` error.

## Changes
- Added MeshPhongMaterial class based on MeshLambertMaterial
- Includes Phong-specific properties: shininess, emissive, specular
- Exported MeshPhongMaterial in THREE object

Generated with [Claude Code](https://claude.ai/code)