### PR TITLE
Fix RingGeometry constructor error

### DIFF
--- a/three.min.js
+++ b/three.min.js
@@ -269,6 +269,57 @@
         }
     };
     
+    // RingGeometry class
+    function RingGeometry(innerRadius = 0.5, outerRadius = 1, thetaSegments = 16, phiSegments = 1, thetaStart = 0, thetaLength = Math.PI * 2) {
+        Geometry.call(this);
+        this.innerRadius = innerRadius;
+        this.outerRadius = outerRadius;
+        this.thetaSegments = Math.max(3, thetaSegments);
+        this.phiSegments = Math.max(1, phiSegments);
+        this.thetaStart = thetaStart;
+        this.thetaLength = thetaLength;
+        this.type = 'RingGeometry';
+        this.generateRing();
+    }
+    RingGeometry.prototype = Object.create(Geometry.prototype);
+    RingGeometry.prototype.constructor = RingGeometry;
+    
+    RingGeometry.prototype.generateRing = function() {
+        // Generate ring vertices
+        this.vertices = [];
+        this.faces = [];
+        
+        const segment = this.thetaLength / this.thetaSegments;
+        
+        // Create vertices
+        for (let j = 0; j <= this.phiSegments; j++) {
+            const radius = this.innerRadius + (this.outerRadius - this.innerRadius) * (j / this.phiSegments);
+            
+            for (let i = 0; i <= this.thetaSegments; i++) {
+                const theta = this.thetaStart + i * segment;
+                const x = radius * Math.cos(theta);
+                const z = radius * Math.sin(theta);
+                this.vertices.push([x, 0, z]);
+            }
+        }
+        
+        // Create faces
+        for (let j = 0; j < this.phiSegments; j++) {
+            const thetaSegmentLevel = this.thetaSegments + 1;
+            
+            for (let i = 0; i < this.thetaSegments; i++) {
+                const v1 = i + j * thetaSegmentLevel;
+                const v2 = i + 1 + j * thetaSegmentLevel;
+                const v3 = i + 1 + (j + 1) * thetaSegmentLevel;
+                const v4 = i + (j + 1) * thetaSegmentLevel;
+                
+                // Create two triangles for each quad
+                this.faces.push([v1, v2, v4]);
+                this.faces.push([v2, v3, v4]);
+            }
+        }
+    };
+    
     // Mesh class
     function Mesh(geometry, material) {
         Object3D.call(this);
@@ -616,6 +667,7 @@
         BoxGeometry: BoxGeometry,
         PlaneGeometry: PlaneGeometry,
         CylinderGeometry: CylinderGeometry,
+        RingGeometry: RingGeometry,
         MeshLambertMaterial: MeshLambertMaterial,
         MeshPhongMaterial: MeshPhongMaterial,
         Mesh: Mesh,


### PR DESCRIPTION
Fixes issue #30 - ゲームの始まりに失敗

Added missing RingGeometry class to resolve `TypeError: THREE.RingGeometry is not a constructor` error.

## Changes
- Added RingGeometry class with innerRadius, outerRadius, thetaSegments support
- Implemented generateRing method for vertex and face generation
- Exported RingGeometry in THREE object

Generated with [Claude Code](https://claude.ai/code)