### PR TITLE
fix: Resolve GitHub Pages deployment issues and improve initialization handling

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -110,8 +110,19 @@ class GameManager {
     
     async startGame() {
         if (!this.isInitialized) {
-            this.uiManager.showError('ゲームが初期化されていません');
-            return;
+            console.log('ゲームが初期化されていません - 再初期化を試行...');
+            // Try to re-initialize
+            try {
+                await this.init();
+                if (!this.isInitialized) {
+                    this.uiManager.showError('ゲームが初期化されていません。ページを再読み込みしてください。');
+                    return;
+                }
+            } catch (error) {
+                console.error('再初期化失敗:', error);
+                this.uiManager.showError('ゲームの初期化に失敗しました:\n' + error.message);
+                return;
+            }
         }
         
         try {
@@ -189,7 +200,7 @@ class GameManager {
     initPWA() {
         // Service Worker登録
         if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('/sw.js')
+            navigator.serviceWorker.register('./sw.js')
                 .then(registration => {
                     console.log('Service Worker 登録成功:', registration);
                 })

--- a/manifest.json
+++ b/manifest.json
@@ -2,13 +2,13 @@
   "name": "3D迷路ゲーム",
   "short_name": "3D迷路",
   "description": "ウェブで動く3D迷路ゲーム",
-  "start_url": "/",
+  "start_url": "./",
   "display": "fullscreen",
   "orientation": "portrait",
   "theme_color": "#2563eb",
   "background_color": "#000000",
   "categories": ["games", "entertainment"],
-  "scope": "/",
+  "scope": "./",
   "icons": [
     {
       "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><rect width='512' height='512' fill='%23000'/><text x='256' y='350' font-size='300' text-anchor='middle' fill='%23fff'>🎮</text></svg>",

--- a/sw.js
+++ b/sw.js
@@ -1,15 +1,16 @@
 // Service Worker for 3D Maze Game PWA
 const CACHE_NAME = '3d-maze-game-v1.2';
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/manifest.json',
-  '/js/maze-generator.js',
-  '/js/game-engine.js',
-  '/js/controls.js',
-  '/js/ui-manager.js',
-  '/js/main.js',
-  'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js'
+  './',
+  './index.html',
+  './manifest.json',
+  './three.min.js',
+  './js/maze-generator.js',
+  './js/game-engine.js',
+  './js/controls.js',
+  './js/ui-manager.js',
+  './js/main.js',
+  './js/three-compatibility.js'
 ];
 
 // インストール時のキャッシュ


### PR DESCRIPTION
Fixes #44

This PR resolves the startup errors that were preventing the game from working on GitHub Pages.

## Changes
- Fix service worker registration path for GitHub Pages subdirectory deployment
- Update manifest.json URLs to use relative paths
- Fix service worker cache URLs to use relative paths
- Update cached resources to include local Three.js implementation
- Add automatic re-initialization in startGame() for better error recovery
- Improve error handling with retry mechanism

## Technical Details
- Resolves 404 errors for `/sw.js` and `/manifest.json`
- Ensures proper resource loading in GitHub Pages subdirectory
- Eliminates "初期化されてません" error message
- Provides robust initialization with automatic retry

## Testing
The game should now start properly at https://maskin.github.io/MindTravel3D/

🤖 Generated with [Claude Code](https://claude.ai/code)